### PR TITLE
Travis: Fix apparent typo in Go version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 sudo: false
 go:
-  - "1.1.x"
+  - "1.x"
 
 script:
   - cd $HOME/gopath/src/github.com/miekg/exdns/q; go build


### PR DESCRIPTION
Was introduced in 417eb539cc449d2ddcae4aa0638b32c35893380f.  Go 1.1 is ancient and AFAIK miekg/dns isn't expected to build on it.